### PR TITLE
add limit feature

### DIFF
--- a/javascript/abyme_controller.js
+++ b/javascript/abyme_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['template', 'associations'];
+  static targets = ['template', 'associations', 'fields'];
 
   connect() {
     console.log('Abyme Connect');
@@ -14,47 +14,43 @@ export default class extends Controller {
   add_association(event) {
     event.preventDefault();
 
-    let html = this.templateTarget.innerHTML.replace(
-      /NEW_RECORD/g,
-      new Date().getTime()
-    );
-
-    if (html.match(/<template[\s\S]+<\/template>/)) {
-      const template = html
-        .match(/<template[\s\S]+<\/template>/)[0]
-        .replace(/(\[\d{12,}\])(\[[^\[\]]+\]"){1}/g, `[NEW_RECORD]$2`);
-
-      html = html.replace(/<template[\s\S]+<\/template>/g, template);
+    // check for limit reached
+    if (this.element.dataset.limit && this.limit_check()) {
+      this.create_event('limit-reached')
+      return false
     }
 
-    this.create_event('before-add', html)
+
+    const html = this.build_html();
+    this.create_event('before-add');
     this.associationsTarget.insertAdjacentHTML(this.position, html);
-    this.create_event('after-add', html)
+    this.create_event('after-add');
   }
 
   remove_association(event) {
     event.preventDefault();
 
-    this.create_event('before-remove')
-    let wrapper = event.target.closest('.abyme--fields');
-    wrapper.querySelector("input[name*='_destroy']").value = 1;
-    wrapper.style.display = 'none';
-    this.create_event('after-remove')
+
+    this.create_event('before-remove');
+    this.mark_for_destroy(event);
+    this.create_event('after-remove');
   }
 
+  // LIFECYCLE EVENTS RELATED
+
   create_event(stage, html = null) {
-    const event = new CustomEvent(`abyme:${stage}`, { detail: {controller: this, content: html} })
-    this.element.dispatchEvent(event)
+    const event = new CustomEvent(`abyme:${stage}`, { detail: {controller: this, content: html} });
+    this.element.dispatchEvent(event);
     // WIP
-    this.dispatch(event, stage)
+    this.dispatch(event, stage);
   }
 
   // WIP : Trying to integrate event handling through controller inheritance
   dispatch(event, stage) {
-    if (stage === 'before-add' && this.abymeBeforeAdd) this.abymeBeforeAdd(event)
-    if (stage === 'after-add' && this.abymeAfterAdd) this.abymeAfterAdd(event)
-    if (stage === 'before-remove' && this.abymeBeforeRemove) this.abymeBeforeAdd(event)
-    if (stage === 'after-remove' && this.abymeAfterRemove) this.abymeAfterRemove(event)
+    if (stage === 'before-add' && this.abymeBeforeAdd) this.abymeBeforeAdd(event);
+    if (stage === 'after-add' && this.abymeAfterAdd) this.abymeAfterAdd(event);
+    if (stage === 'before-remove' && this.abymeBeforeRemove) this.abymeBeforeAdd(event);
+    if (stage === 'after-remove' && this.abymeAfterRemove) this.abymeAfterRemove(event);
   }
 
   abymeBeforeAdd(event) {
@@ -67,5 +63,40 @@ export default class extends Controller {
   }
 
   abymeAfterRemove(event) {
+  }
+
+  // UTILITIES
+
+  // build html
+  build_html() {
+    let html = this.templateTarget.innerHTML.replace(
+      /NEW_RECORD/g,
+      new Date().getTime()
+    );
+      
+    if (html.match(/<template[\s\S]+<\/template>/)) {
+      const template = html
+      .match(/<template[\s\S]+<\/template>/)[0]
+      .replace(/(\[\d{12,}\])(\[[^\[\]]+\]"){1}/g, `[NEW_RECORD]$2`);
+      
+      html = html.replace(/<template[\s\S]+<\/template>/g, template);
+    }
+
+    return html;
+  }
+    
+  // mark association for destroy
+  mark_for_destroy(event) {
+    let item = event.target.closest('.abyme--fields');
+    item.querySelector("input[name*='_destroy']").value = 1;
+    item.style.display = 'none';
+    item.classList.add('abyme--marked-for-destroy')
+  }
+
+  // check if associations limit is reached
+  limit_check() {
+    return (this.fieldsTargets
+                .filter(item => !item.classList.contains('abyme--marked-for-destroy'))).length 
+                >= parseInt(this.element.dataset.limit)
   }
 }

--- a/javascript/abyme_controller.js
+++ b/javascript/abyme_controller.js
@@ -20,7 +20,6 @@ export default class extends Controller {
       return false
     }
 
-
     const html = this.build_html();
     this.create_event('before-add');
     this.associationsTarget.insertAdjacentHTML(this.position, html);
@@ -65,7 +64,7 @@ export default class extends Controller {
   abymeAfterRemove(event) {
   }
 
-  // UTILITIES
+  // ** UTILITIES FUNCTIONS ** //
 
   // build html
   build_html() {

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -1,10 +1,8 @@
-require 'abyme/abyme_builder'
-
 module Abyme
   module ViewHelpers
 
     def abymize(association, form, options = {}, &block)
-      content_tag(:div, data: { controller: 'abyme' }, id: "abyme--#{association}") do
+      content_tag(:div, data: { controller: 'abyme', limit: options[:limit] }, id: "abyme--#{association}") do
         if block_given?
           yield(Abyme::AbymeBuilder.new(association: association, form: form, lookup_context: self.lookup_context))
         else
@@ -20,13 +18,9 @@ module Abyme
       content_tag(:div, data: { target: 'abyme.associations', association: association, abyme_position: options[:position] || :end }) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, basic_markup(options[:html])) do
-              if block_given?
-                # Here, f is the fields_for ; f.object becomes association.new rather than the original form.object
-                yield(f)
-              else
-                render "abyme/#{association.to_s.singularize}_fields", f: f
-              end
+            content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+              # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
+              block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
           end
         end
@@ -34,30 +28,18 @@ module Abyme
     end
   
     def persisted_records_for(association, form, options = {})
-      if options[:collection]
-        records = options[:collection]
-      else
-        records = form.object.send(association)
-      end
+      records = options[:collection] || form.object.send(association)
       
       if options[:order].present?
         records = records.order(options[:order])
-        
-        # GET INVALID RECORDS
+        # Get invalid records
         invalids = form.object.send(association).reject(&:persisted?)
-        
-        if invalids.any?
-          records = records.to_a.concat(invalids)
-        end
+        records = records.to_a.concat(invalids) if invalids.any?
       end
 
       form.fields_for(association, records) do |f|
-        content_tag(:div, basic_markup(options[:html])) do
-          if block_given?
-            yield(f)
-          else
-            render "abyme/#{association.to_s.singularize}_fields", f: f
-          end
+        content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+          block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
         end
       end
     end
@@ -89,16 +71,13 @@ module Abyme
     end
 
     def basic_markup(html)
-
       if html && html[:class]
         html[:class] = 'abyme--fields ' + html[:class]
       else
         html ||= {}
         html[:class] = 'abyme--fields'
       end
-
-      return html
+      html
     end
-
   end
 end


### PR DESCRIPTION
### limit feature
added a limit feature to set a maximum number of associations fields to display.
you can now set the limit on the top level wrapper (abymize):

<img width="511" alt="Capture d’écran 2020-10-14 à 01 11 56" src="https://user-images.githubusercontent.com/34983046/95927023-fd9f7d00-0dbd-11eb-8466-5ff29e10d15d.png">


it make more sense to set the limit on the abymize level because the limit will apply for both records & new_records

### JS
a new custom event (abyme:limit-reached) is now fired when the maximum number of associations fields is reached

plus some refacto of the AbymeController to make the code more clear