### PR TITLE
limit & min count options

### DIFF
--- a/javascript/abyme_controller.js
+++ b/javascript/abyme_controller.js
@@ -1,19 +1,26 @@
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['template', 'associations', 'fields'];
+  static targets = ['template', 'associations', 'fields', 'newFields'];
 
   connect() {
-    console.log('Abyme Connect');
+    if (this.count) {
+      this.addDefaultAssociations();
+    }
   }
 
+  get count() {
+    return this.element.dataset.minCount || 0;
+  }
+  
   get position() {
     return this.associationsTarget.dataset.abymePosition === 'end' ? 'beforeend' : 'afterbegin';
   }
 
   add_association(event) {
-    event.preventDefault();
-
+    if (event) {
+      event.preventDefault();
+    }
     // check for limit reached
     if (this.element.dataset.limit && this.limit_check()) {
       this.create_event('limit-reached')
@@ -28,8 +35,6 @@ export default class extends Controller {
 
   remove_association(event) {
     event.preventDefault();
-
-
     this.create_event('before-remove');
     this.mark_for_destroy(event);
     this.create_event('after-remove');
@@ -64,7 +69,7 @@ export default class extends Controller {
   abymeAfterRemove(event) {
   }
 
-  // ** UTILITIES FUNCTIONS ** //
+  // UTILITIES
 
   // build html
   build_html() {
@@ -94,8 +99,23 @@ export default class extends Controller {
 
   // check if associations limit is reached
   limit_check() {
-    return (this.fieldsTargets
+    return (this.newFieldsTargets
                 .filter(item => !item.classList.contains('abyme--marked-for-destroy'))).length 
                 >= parseInt(this.element.dataset.limit)
+  }
+
+  // Add default blank associations at page load
+  async addDefaultAssociations() {
+    let i = 0
+    while (i < this.count) {
+      this.add_association()
+      i++
+      // Sleep function to ensure uniqueness of timestamp
+      await this.sleep(1);
+    }
+  }
+
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -2,9 +2,12 @@ module Abyme
   module ViewHelpers
 
     def abymize(association, form, options = {}, &block)
-      content_tag(:div, data: { controller: 'abyme', limit: options[:limit] }, id: "abyme--#{association}") do
+      content_tag(:div, data: { controller: 'abyme', limit: options[:limit], min_count: options[:min_count] }, id: "abyme--#{association}") do
         if block_given?
-          yield(Abyme::AbymeBuilder.new(association: association, form: form, lookup_context: self.lookup_context))
+          yield(Abyme::AbymeBuilder.new(
+            association: association, form: form, lookup_context: self.lookup_context, partial: options[:partial]
+            )
+          )
         else
           model = association.to_s.singularize.classify.constantize
           concat(persisted_records_for(association, form, options))
@@ -17,8 +20,9 @@ module Abyme
     def new_records_for(association, form, options = {}, &block)
       content_tag(:div, data: { target: 'abyme.associations', association: association, abyme_position: options[:position] || :end }) do
         content_tag(:template, class: "abyme--#{association.to_s.singularize}_template", data: { target: 'abyme.template' }) do
+
           form.fields_for association, association.to_s.classify.constantize.new, child_index: 'NEW_RECORD' do |f|
-            content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+            content_tag(:div, basic_markup(options[:html], association).merge(data: { target: 'abyme.fields abyme.newFields' })) do
               # Here, if a block is passed, we're passing the association fields to it, rather than the form itself
               block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
             end
@@ -38,7 +42,7 @@ module Abyme
       end
 
       form.fields_for(association, records) do |f|
-        content_tag(:div, basic_markup(options[:html]).merge(data: { target: 'abyme.fields' })) do
+        content_tag(:div, basic_markup(options[:html], association).merge(data: { target: 'abyme.fields' })) do
           block_given? ? yield(f) : render("abyme/#{association.to_s.singularize}_fields", f: f)
         end
       end
@@ -70,12 +74,12 @@ module Abyme
       end
     end
 
-    def basic_markup(html)
+    def basic_markup(html, association = nil)
       if html && html[:class]
-        html[:class] = 'abyme--fields ' + html[:class]
+        html[:class] = "abyme--fields #{association.to_s.singularize}-fields #{html[:class]}" 
       else
         html ||= {}
-        html[:class] = 'abyme--fields'
+        html[:class] = "abyme--fields #{association.to_s.singularize}-fields"
       end
       html
     end


### PR DESCRIPTION
## Min-count
Added possibility of passing a minimum number of blank records. When passing a min_count: option to abymize, a dataset gets set on the container, which we then user in Stimulus to trigger the add_association as many times as needed.

## Partial option in #abymize
Added option for abymize so that we only pass the custom partial path once, instead of both records and new_records methods. They still retain the possibility of being passed a custom partial directly, should the user want to use a different one for each.

## Default class to easily target fields
Added a more specific singular_association-fields class to every fields (in addition to the abyme--fields class. It will probably save the need of passing a custom class to target those (not everyone is wise enough to use Tailwind 🤓)

## Limit option tweak
changed the limit option behaviour, now it will apply on new_records only. persisted records will no longer be affected by the limitation.

plus some frontend adjustments