### PR TITLE
retro compatibility with former public method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/f591a9e00f7cf5188ad5/maintainability)](https://codeclimate.com/github/bear-in-mind/abyme/maintainability)
 [![Coverage Status](https://coveralls.io/repos/github/bear-in-mind/abyme/badge.svg)](https://coveralls.io/github/bear-in-mind/abyme?branch=master)
 
-abyme is an easy and framework-agnostic way to handle nested attributes in Rails, using [stimulus](https://stimulusjs.org/handbook/introduction) under the hood. Here's an example :
+abyme is an easy and form-agnostic way to handle nested attributes in Rails, using [stimulus](https://stimulusjs.org/handbook/introduction) under the hood. Here's an example :
 ```ruby
 # views/projects/_form.html.erb
 <%= form_for @project do |f| %>
@@ -40,6 +40,7 @@ In views:
 - `add_association` became `add_associated_record`
 - `remove_association` became `remove_associated_record`
 
+The former method names will be deprecated soon.
 If you update, don't forget to change those ! All changes are reflected in the README below.
 
 ## Installation

--- a/lib/abyme/action_view_extensions/builder.rb
+++ b/lib/abyme/action_view_extensions/builder.rb
@@ -4,6 +4,8 @@ module Abyme
       def abyme_for(association, options = {}, &block)
         @template.abyme_for(association, self, options, &block)
       end
+
+      alias :abymize :abyme_for
     end
   end
 end

--- a/lib/abyme/model.rb
+++ b/lib/abyme/model.rb
@@ -10,6 +10,8 @@ module Abyme
         Abyme::Model.permit_attributes(self.name, association, permit || reject, permit.present?) if permit.present? || reject.present?
       end
 
+      alias :abyme_for :abymize
+
       def abyme_attributes
         Abyme::Model.instance_variable_get(:@permitted_attributes)[self.name]
       end

--- a/lib/abyme/view_helpers.rb
+++ b/lib/abyme/view_helpers.rb
@@ -54,6 +54,8 @@ module Abyme
       end
     end
 
+    alias :abymize :abyme_for
+
     # NEW_RECORDS_FOR
 
     # this helper is call by the AbymeBuilder #new_records instance method
@@ -202,6 +204,9 @@ module Abyme
       options[:content] ||= 'Remove Association'
       create_button(action, options, &block)
     end
+
+    alias :add_association    :add_associated_record 
+    alias :remove_association :remove_associated_record
 
     private
 

--- a/spec/dummy/app/views/abyme/_meeting_fields.html.erb
+++ b/spec/dummy/app/views/abyme/_meeting_fields.html.erb
@@ -1,0 +1,16 @@
+<%# Trying to reference controller methods and collections to check if context is passed ; otherwise these will raise an error %>
+<% current_user %>
+<% @collection %>
+
+<div class="field mb-4 relative">
+  <%= f.text_field :start_time, class: 'text-4xl font-bold mb-4 w-full', 
+                      label: false,
+                      placeholder: 'Start...' %>
+  <%= f.text_field :end_time, class: 'text-4xl font-bold mb-4 w-full', 
+                    label: false,
+                    placeholder: 'End...' %>
+  <%= f.hidden_field :_destroy %>
+  <%= remove_association(tag: :div) do %>
+    Remove
+  <% end %>
+</div>

--- a/spec/dummy/app/views/projects/_form.html.erb
+++ b/spec/dummy/app/views/projects/_form.html.erb
@@ -30,6 +30,12 @@
 				) %>
 				<%= add_associated_record(content: 'Add task', html: { id: 'add-task', class: 'border-solid border-2 rounded border-grey-300 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-center items-center leading-normal p-8 cursor-pointer w-full focus:outline-none' }) %>
 			<% end %>
+			<%# Trying old syntax for retrocompatibility %>
+			<%= f.abymize(:meetings) do |abyme| %>
+				<%= abyme.records %>
+				<%= abyme.new_records %>
+				<%= add_association(content: "Add meeting") %>
+			<% end %>
 		</div>
 	</div>
 <% end %>


### PR DESCRIPTION
Added alias method names for all changed method names to ensure backwards compatibility to early users and cocoon-transitioners.